### PR TITLE
Update to ops 2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 lightkube>=0.10.1,<1.0.0
-ops>=1.3.0,<2.0.0
+ops~=2.10
 ops.manifest>=1.1.0,<2.0.0
 pydantic==1.*
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops


### PR DESCRIPTION
It'd be great to move this charm to ops 2.x (and if doing so, then 2.10 would be a good target for now).

All the tests pass for me locally when doing this, so I'm not sure what the motivation was behind pinning to 1.x. It could be that there are issues that aren't caught by the tests that mean more needs to be done here. If you need help moving to 2.x, please reach out to @canonical/charm-tech and we'd be happy to help.