### PR TITLE
Charm config to set the reclaim policy on the default storage class

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/config.yaml
+++ b/config.yaml
@@ -43,3 +43,15 @@ options:
     default: True
     description: |
       Whether to enable the Cinder CSI topology awareness
+
+  reclaim-policy:
+    type: string
+    default: "Delete"
+    description: |
+      https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy
+
+      The reclaim policy for the PVCs created by the CSI driver. This is passed
+      through to the parameters.reclaimPolicy field of the csi-cinder-default
+      StorageClass.
+
+      Potential values are "Delete" or "Retain"

--- a/src/config.py
+++ b/src/config.py
@@ -27,4 +27,6 @@ class CharmConfig:
 
     def evaluate(self) -> Optional[str]:
         """Determine if configuration is valid."""
+        if self.config["reclaim-policy"].title() not in ["Delete", "Retain"]:
+            return "reclaim-policy should be either 'Delete' or 'Retain'"
         return None

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -56,13 +56,15 @@ class CreateStorageClass(Addition):
         """Craft the storage class object."""
         storage_name = STORAGE_CLASS_NAME.format(type=self.type)
         log.info(f"Creating storage class {storage_name}")
+        reclaim_policy: str = self.manifests.config.get("reclaim-policy") or "Delete"
+
         sc = from_dict(
             dict(
                 apiVersion="storage.k8s.io/v1",
                 kind="StorageClass",
                 metadata=dict(name=storage_name),
                 provisioner="cinder.csi.openstack.org",
-                reclaimPolicy="Delete",
+                reclaimPolicy=reclaim_policy.title(),
                 volumeBindingMode="WaitForFirstConsumer",
             )
         )


### PR DESCRIPTION
## Overview

Allow the user to set the reclaim policy of the default storage class created by the charm

## Details

Expose through charm config  two options for the reclaim policy: "Delete" or "Retain".  Users can fat-finger the casing, and the charm will fix it to be appropriately title-cased

The charm will block on other invalid or missing config. 
The default "Delete" is maintained

## Links
* https://bugs.launchpad.net/charm-cinder-csi/+bug/2071824