### PR TITLE
Provide charm config to set the cinder-csi storage class as the default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,3 +55,11 @@ options:
       StorageClass.
 
       Potential values are "Delete" or "Retain"
+
+  storage-class-default:
+    type: boolean
+    default: false
+    description: |
+      https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
+      
+      Whether to set the storage class for the Cinder CSI driver as the cluster default

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -57,12 +57,16 @@ class CreateStorageClass(Addition):
         storage_name = STORAGE_CLASS_NAME.format(type=self.type)
         log.info(f"Creating storage class {storage_name}")
         reclaim_policy: str = self.manifests.config.get("reclaim-policy") or "Delete"
+        is_default: str = "true" if self.manifests.config.get("storage-class-default") else "false"
 
         sc = from_dict(
             dict(
                 apiVersion="storage.k8s.io/v1",
                 kind="StorageClass",
-                metadata=dict(name=storage_name),
+                metadata=dict(
+                    name=storage_name,
+                    annotations={"storageclass.kubernetes.io/is-default-class": is_default},
+                ),
                 provisioner="cinder.csi.openstack.org",
                 reclaimPolicy=reclaim_policy.title(),
                 volumeBindingMode="WaitForFirstConsumer",


### PR DESCRIPTION
## Overview

Addresses [LP#2075336](https://bugs.launchpad.net/charm-cinder-csi/+bug/2075336) by providing charm config to set the storage class as the cluster default

## Details

Adds a true/false config option to annotate the storage class created by this charm as the default-storage-class for the cluster  For backwards compatibility -- it doesn't assert itself as the default