### PR TITLE
Accept proxy-config from clients relation and apply to o7k-ccm container

### DIFF
--- a/.github/workflows/charm-build.yaml
+++ b/.github/workflows/charm-build.yaml
@@ -42,8 +42,7 @@ jobs:
       - name: Upload charm artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openstack-integrator.charm
-          path: ./openstack-integrator*.charm
+          path: ./*.charm
       - name: Upload debug artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,11 @@
 options:
+  availability-zone:
+    type: string
+    default: ""
+    description: |
+      Availability zone to use with Cinder CSI. This is passed through to the
+      parameters.availability field of the csi-cinder-default StorageClass.
+
   image-registry:
     type: string
     description: |
@@ -13,36 +20,13 @@ options:
         juju config cinder-csi image-registry='rocks.canonical.com:443/cdk'
         juju config cinder-csi --reset image-registry
 
-  storage-release:
-    type: string
-    description: |
-      Specify the version of storage-release as defined by the `release`
-      tags of https://github.com/kubernetes/cloud-provider-openstack
-
-      example)
-        juju config cinder-csi storage-release='v1.7.3'
-      
-      A list of supported versions is available through the action:
-        juju run-action cinder-csi/leader list-releases --wait
-      
-      To reset by to the latest supported by the charm use:
-        juju config cinder-csi --reset storage-release
-      
-      The current release deployed is available by viewing
-        juju status cinder-csi
-
-  availability-zone:
-    type: string
-    default: ""
-    description: |
-      Availability zone to use with Cinder CSI. This is passed through to the
-      parameters.availability field of the csi-cinder-default StorageClass.
-
-  topology:
+  juju-model-proxy-enable:
     type: boolean
-    default: True
     description: |
-      Whether to enable the Cinder CSI topology awareness
+      Whether the applications managed by this charm should be
+      proxied using juju's model-config juju-*-proxy settings.
+      (See https://documentation.ubuntu.com/juju/latest/reference/juju-cli/list-of-juju-cli-commands/model-config/).
+    default: false
 
   reclaim-policy:
     type: string
@@ -61,5 +45,28 @@ options:
     default: false
     description: |
       https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
-      
+
       Whether to set the storage class for the Cinder CSI driver as the cluster default
+  storage-release:
+    type: string
+    description: |
+      Specify the version of storage-release as defined by the `release`
+      tags of https://github.com/kubernetes/cloud-provider-openstack
+
+      example)
+        juju config cinder-csi storage-release='v1.7.3'
+
+      A list of supported versions is available through the action:
+        juju run-action cinder-csi/leader list-releases --wait
+
+      To reset by to the latest supported by the charm use:
+        juju config cinder-csi --reset storage-release
+
+      The current release deployed is available by viewing
+        juju status cinder-csi
+
+  topology:
+    type: boolean
+    default: True
+    description: |
+      Whether to enable the Cinder CSI topology awareness

--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@ options:
         juju config cinder-csi image-registry='rocks.canonical.com:443/cdk'
         juju config cinder-csi --reset image-registry
 
-  juju-model-proxy-enable:
+  web-proxy-enable:
     type: boolean
     description: |
       Whether the applications managed by this charm should be

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-lightkube>=0.10.1,<1.0.0
+lightkube
 ops
 ops.manifest>=1.1.0,<2.0.0
 pydantic==1.*
-ops.interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@edc07bce7ea4c25d472fa4d95834602a7ebce5cd#subdirectory=ops
+ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@4a1081da098154b96337a09c8e9c40acff2d330e#subdirectory=ops
-ops.interface-openstack-integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@066d177e8ef1acb1e7b1d92832a32c9a1fb41c9e#subdirectory=ops
+ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@KU-3229/support-o7k-endpoint-through-proxy#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic==1.*
 ops.interface-kube_control==0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@4a1081da098154b96337a09c8e9c40acff2d330e#subdirectory=ops
 ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops
-jmodelproxylib @ git+https://github.com/addyess/jmodelproxylib@main
+charms.proxylib == 0.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-lightkube
-ops
+lightkube==0.17.2
+ops==2.22.0
 ops.manifest>=1.1.0,<2.0.0
 pydantic==1.*
-ops.interface-kube_control == 0.2.0
+ops.interface-kube_control==0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@4a1081da098154b96337a09c8e9c40acff2d330e#subdirectory=ops
 ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops
 jmodelproxylib @ git+https://github.com/addyess/jmodelproxylib@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ops.manifest>=1.1.0,<2.0.0
 pydantic==1.*
 ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@4a1081da098154b96337a09c8e9c40acff2d330e#subdirectory=ops
-ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@KU-3229/support-o7k-endpoint-through-proxy#subdirectory=ops
+ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ops.manifest>=1.1.0,<2.0.0
 pydantic==1.*
 ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@4a1081da098154b96337a09c8e9c40acff2d330e#subdirectory=ops
-ops.interface_openstack_integration @ git+https://github.com/canonical/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops
+ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic==1.*
 ops.interface-kube_control == 0.2.0
 ops.interface-tls-certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@4a1081da098154b96337a09c8e9c40acff2d330e#subdirectory=ops
 ops.interface_openstack_integration @ git+https://github.com/charmed-kubernetes/interface-openstack-integration.git@cf4383999b0920b226104299f4defb3576680d72#subdirectory=ops
+jmodelproxylib @ git+https://github.com/addyess/jmodelproxylib@main

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -26,7 +26,16 @@ log = logging.getLogger(__file__)
 NAMESPACE = "kube-system"
 SECRET_NAME = "csi-cinder-cloud-config"
 STORAGE_CLASS_NAME = "csi-cinder-{type}"
-K8S_DEFAULT_NO_PROXY = ["127.0.0.1", "localhost", "::1", "svc", "svc.cluster", "svc.cluster.local"]
+OPENSTACK_METADATA_SERVER = "169.254.169.254"
+K8S_DEFAULT_NO_PROXY = [
+    "127.0.0.1",
+    OPENSTACK_METADATA_SERVER, # this should always skip the proxy
+    "localhost",
+    "::1",
+    "svc",
+    "svc.cluster",
+    "svc.cluster.local",
+]
 
 
 class CreateSecret(Addition):

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__file__)
 NAMESPACE = "kube-system"
 SECRET_NAME = "csi-cinder-cloud-config"
 STORAGE_CLASS_NAME = "csi-cinder-{type}"
-K8S_DEFAULT_SVC = "kubernetes.default.svc"
+K8S_DEFAULT_NO_PROXY = ["127.0.0.1", "localhost", "::1", "svc", "svc.cluster", "svc.cluster.local"]
 
 
 class CreateSecret(Addition):
@@ -103,19 +103,17 @@ def _proxy_config_to_env_vars(proxy_config: Dict[str, str]) -> List[EnvVar]:
     """
     if not proxy_config:
         return []
-    # Confirm all keys are upper case, all values are strings
-    as_upper = {k.upper(): (v or "") for k, v in proxy_config.items()}
-    # Confirm no empty values for each of the required fields
-    required_fields = {"HTTP_PROXY": "", "HTTPS_PROXY": "", "NO_PROXY": ""}
-    all_fields = {**required_fields, **as_upper}
+    fields = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"]
+    settings = {k: (proxy_config.get(k) or "") for k in fields}
+    settings.update({k: (proxy_config.get(k) or "") for k in map(str.lower, fields)})
     env_vars = []
-    for key, value in all_fields.items():
+    for key, value in settings.items():
         # Only add env vars that are not empty
-        if key == "NO_PROXY" and K8S_DEFAULT_SVC not in value:
-            # Add kubernetes.default.svc to no_proxy
-            value = ",".join(filter(None, [K8S_DEFAULT_SVC, value]))
-        if key in required_fields:
-            env_vars.append(EnvVar(name=key, value=value))
+        if key.upper() == "NO_PROXY":
+            # Ensure no_proxy_extras are included
+            uniq_seen = dict.fromkeys(K8S_DEFAULT_NO_PROXY + value.split(","))
+            value = ",".join(filter(None, uniq_seen))
+        env_vars.append(EnvVar(name=key, value=value))
     return env_vars
 
 

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -8,7 +8,7 @@ import pickle
 from hashlib import md5
 from typing import Dict, List, Optional
 
-import jmodelproxylib
+import charms.proxylib
 from lightkube import Client
 from lightkube.codecs import AnyResource, from_dict
 from lightkube.models.core_v1 import Event, Pod
@@ -29,7 +29,7 @@ STORAGE_CLASS_NAME = "csi-cinder-{type}"
 OPENSTACK_METADATA_SERVER = "169.254.169.254"
 K8S_DEFAULT_NO_PROXY = [
     "127.0.0.1",
-    OPENSTACK_METADATA_SERVER, # this should always skip the proxy
+    OPENSTACK_METADATA_SERVER,  # this should always skip the proxy
     "localhost",
     "::1",
     "svc",
@@ -135,9 +135,9 @@ class UpdateCSIDriver(Patch):
                     if env.name == "CLUSTER_NAME":
                         env.value = self.manifests.config.get("cluster-name")
 
-                enabled = self.manifests.config.get("juju-model-proxy-enable")
-                env = jmodelproxylib.environ(enabled=enabled, add_no_proxies=K8S_DEFAULT_NO_PROXY)
-                container.env.extend(jmodelproxylib.container_vars(env))
+                enabled = self.manifests.config.get("web-proxy-enable")
+                env = charms.proxylib.environ(enabled=enabled, add_no_proxies=K8S_DEFAULT_NO_PROXY)
+                container.env.extend(charms.proxylib.container_vars(env))
 
 
 class StorageManifests(Manifests):

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import datetime
+import logging
+
+from lightkube.resources.apps_v1 import Deployment
+from lightkube.resources.core_v1 import Event, Pod
+
+log = logging.getLogger(__name__)
+
+
+async def test_get_events(kubernetes):
+    deployment = await kubernetes.get(
+        Deployment, name="csi-cinder-controllerplugin", namespace="kube-system"
+    )
+    deployment_events = []
+    async for event in kubernetes.list(
+        Event,
+        namespace=deployment.metadata.namespace,
+        fields={
+            "involvedObject.kind": "Deployment",
+            "involvedObject.name": deployment.metadata.name,
+        },
+    ):
+        deployment_events.append(event)
+
+    pod_events = []
+    async for pod in kubernetes.list(
+        Pod,
+        namespace=deployment.metadata.namespace,
+        labels={"app": deployment.metadata.name},
+    ):
+        async for event in kubernetes.list(
+            Event,
+            namespace=pod.metadata.namespace,
+            fields={
+                "involvedObject.kind": "Pod",
+                "involvedObject.name": pod.metadata.name,
+            },
+        ):
+            pod_events.append(event)
+
+    for event in sorted(deployment_events + pod_events, key=by_localtime):
+        log.info(
+            "Event %s/%s %s msg=%s",
+            event.involvedObject.kind,
+            event.involvedObject.name,
+            event.lastTimestamp and event.lastTimestamp.astimezone() or "Date not recorded",
+            event.message,
+        )
+
+
+def by_localtime(event: Event) -> datetime.datetime:
+    """Return the last timestamp of the event."""
+    dt = event.lastTimestamp or datetime.datetime.now()
+    return dt.astimezone()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -48,6 +48,7 @@ def integrator():
         integrator.evaluate_relation.return_value = None
         integrator.cloud_conf_b64 = b"abc"
         integrator.endpoint_tls_ca = b"def"
+        integrator.proxy_config = {}
         yield integrator
 
 

--- a/tests/unit/test_storage_manifest.py
+++ b/tests/unit/test_storage_manifest.py
@@ -1,0 +1,117 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+import unittest.mock as mock
+
+import pytest
+from lightkube.models.core_v1 import Container, EnvVar, Volume
+from lightkube.resources.apps_v1 import DaemonSet, Deployment
+
+import storage_manifests
+from charm import CinderCSICharm, KubeControlRequirer, OpenstackIntegrationRequirer
+from config import CharmConfig
+
+CLUSTER_NAME = "k8s-cluster-name"
+PROXY_URL = "http://proxy:80"
+PROXY_URL_1 = f"{PROXY_URL}81"
+PROXY_URL_2 = f"{PROXY_URL}82"
+NO_PROXY = "127.0.0.1,localhost,::1,example.com"
+
+
+@pytest.fixture
+def charm_config():
+    """Return the charm config."""
+    config = mock.MagicMock(spec=CharmConfig)
+    config.available_data = {
+        "cloud-conf": "abc",
+        "endpoint-ca-cert": "def",
+    }
+    return config
+
+
+@pytest.fixture
+def kube_control():
+    """Return the kube control mock."""
+    kube_control = mock.MagicMock(spec=KubeControlRequirer)
+    kube_control.evaluate_relation.return_value = None
+    kube_control.get_registry_location.return_value = "rocks.canonical.com/cdk"
+    kube_control.kubeconfig = b"abc"
+    kube_control.get_cluster_tag.return_value = CLUSTER_NAME
+    return kube_control
+
+
+@pytest.fixture(params=[None, "", NO_PROXY])
+def no_proxy(request):
+    """Return the no_proxy value."""
+    return request.param
+
+
+@pytest.fixture
+def integrator(no_proxy):
+    """Return the openstack integration mock."""
+    integrator = mock.MagicMock(spec=OpenstackIntegrationRequirer)
+    integrator.evaluate_relation.return_value = None
+    integrator.cloud_conf_b64 = b"abc"
+    integrator.endpoint_tls_ca = b"def"
+    integrator.proxy_config = {
+        "HTTP_PROXY": PROXY_URL_1,
+        "HTTPS_PROXY": PROXY_URL_2,
+        "NO_PROXY": no_proxy,
+        "http_proxy": PROXY_URL_1,
+        "https_proxy": PROXY_URL_2,
+        "no_proxy": no_proxy,
+    }
+    return integrator
+
+
+@pytest.fixture
+def storage(kube_control, charm_config, integrator):
+    """Return the manifests object."""
+    yield storage_manifests.StorageManifests(
+        mock.MagicMock(spec=CinderCSICharm),
+        charm_config,
+        kube_control,
+        integrator,
+    )
+
+
+@pytest.mark.parametrize(
+    "resource,name",
+    [
+        (DaemonSet, "csi-cinder-nodeplugin"),
+        (Deployment, "csi-cinder-controllerplugin"),
+    ],
+)
+def test_patch_csi_driver(storage, resource, name, no_proxy):
+    """Test the patching of the csi_driver executables."""
+    update_rsc = storage.manipulations[-1]
+    assert isinstance(update_rsc, storage_manifests.UpdateCSIDriver)
+
+    secret_volume = mock.MagicMock(spec=Volume)
+    cluster_env = EnvVar(name="CLUSTER_NAME", value="set-me")
+
+    container = mock.MagicMock(spec=Container)
+    container.name = "cinder-csi-plugin"
+    container.env = [cluster_env]
+
+    rsc = mock.MagicMock(spec=resource)
+    rsc.kind = resource._api_info.resource.kind
+    rsc.metadata.name = name
+    rsc.spec.template.spec.volumes = [secret_volume]
+    rsc.spec.template.spec.containers = [container]
+    split_no_proxy = no_proxy.split(",") if no_proxy else []
+    expected_no_proxy = ",".join(
+        dict.fromkeys(storage_manifests.K8S_DEFAULT_NO_PROXY + split_no_proxy)
+    )
+
+    update_rsc(rsc)
+    assert secret_volume.secret.secretName == storage_manifests.SECRET_NAME
+    assert EnvVar(name="CLUSTER_NAME", value=CLUSTER_NAME) in container.env
+    assert EnvVar(name="HTTP_PROXY", value=PROXY_URL_1) in container.env
+    assert EnvVar(name="HTTPS_PROXY", value=PROXY_URL_2) in container.env
+    assert EnvVar(name="NO_PROXY", value=expected_no_proxy) in container.env
+    assert EnvVar(name="http_proxy", value=PROXY_URL_1) in container.env
+    assert EnvVar(name="https_proxy", value=PROXY_URL_2) in container.env
+    assert EnvVar(name="no_proxy", value=expected_no_proxy) in container.env

--- a/tests/unit/test_storage_manifest.py
+++ b/tests/unit/test_storage_manifest.py
@@ -40,7 +40,7 @@ def charm_config(respect_proxy, no_proxy):
     config.available_data = {
         "cloud-conf": "abc",
         "endpoint-ca-cert": "def",
-        "juju-model-proxy-enable": respect_proxy,
+        "web-proxy-enable": respect_proxy,
     }
     env = {
         "JUJU_CHARM_HTTPS_PROXY": PROXY_URL_1,

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
+    pytest-sugar
     pytest-cov
     ipdb
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -102,5 +102,8 @@ ignore_missing_imports = True
 [mypy-lightkube.*]
 ignore_missing_imports = True
 
+[mypy-jmodelproxylib.*]
+ignore_missing_imports = True
+
 [isort]
 profile = black

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ ignore_missing_imports = True
 [mypy-lightkube.*]
 ignore_missing_imports = True
 
-[mypy-jmodelproxylib.*]
+[mypy-charms.*]
 ignore_missing_imports = True
 
 [isort]


### PR DESCRIPTION
Resolves: [LP#2104884](https://bugs.launchpad.net/charm-openstack-integrator/+bug/2104884)

### Overview
1) Contact O7K endpoints through the http proxy settings determined by the `juju-model-proxy-enable` config

### Details
this dictionary will be filled by the `juju model-config` with the following env variables: 
* `juju-http-proxy` --> `HTTP_PROXY`
* `juju-https-proxy` --> `HTTPS_PROXY`
* `juju-no-proxy` --> `NO_PROXY`
* `juju-http-proxy` --> `http_proxy`
* `juju-http-proxy` --> `https_proxy`
* `juju-http-proxy` --> `no_proxy`

The storage-manifest ensures that both `no_proxy` and `NO_PROXY` have specific hostname carve-outs for in cluster domains