### PR TITLE
Schedule cinder-csi controller plugin to run on control-plane nodes

### DIFF
--- a/tests/data/kube_control_data.yaml
+++ b/tests/data/kube_control_data.yaml
@@ -15,7 +15,7 @@ creds: |-
     "cinder-csi/0": {
       "client_token": "admin::reacted",
       "kubelet_token": "cinder-csi/0::reacted",
-      "proxy_token": "kube-proxy::reacted", 
+      "proxy_token": "kube-proxy::reacted",
       "scope": "kubernetes-worker/0"
     }
   }
@@ -30,4 +30,4 @@ private-address: 10.246.154.7
 registry-location: rocks.canonical.com:443/cdk
 sdn-ip: 10.152.183.20
 taints: '["node-role.kubernetes.io/control-plane=true:NoSchedule"]'
-labels: '["node-role.kubernetes.io/control-plane=true"]'
+labels: '["node-role.kubernetes.io/control-plane="]'

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -161,6 +161,7 @@ def test_waits_for_kube_control(mock_create_kubeconfig, harness, caplog):
     storage_messages = {r.message for r in caplog.records if "storage" in r.filename}
 
     assert storage_messages == {
+        'Applying Control Node Selector as node-role.kubernetes.io/control-plane: ""',
         "Encode secret data for storage.",
         "Creating storage class csi-cinder-default",
         "Setting secret for DaemonSet/csi-cinder-nodeplugin",

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -2,6 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Update to a new upstream release."""
+
 import argparse
 import contextlib
 import json


### PR DESCRIPTION
Fixes: [LP#2111904](https://bugs.launchpad.net/charm-cinder-csi/+bug/2111904)

### Overview
The cinder-csi controller deployments aren't specifically scheduled to run on any specific nodes.  These changes lock the pods to only run on controller nodes. 