### PR TITLE
Tolerate control-plane taints since we're forcing scheduling to the control-planes

### DIFF
--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -204,7 +204,7 @@ class StorageManifests(Manifests):
             "cloud-conf": (val := self.integrator.cloud_conf_b64) and val.decode(),
             "control-node-selector": controller_labels,
             "control-node-taints": self.kube_control.get_controller_taints()
-            or [Taint("NoSchedule", "node-role.kubernetes.io/control-plane")],  # by default
+            or [Taint(key="node-role.kubernetes.io/control-plane", effect="NoSchedule")],  # by default
             "endpoint-ca-cert": (val := self.integrator.endpoint_tls_ca) and val.decode(),
             **self.charm_config.available_data,
         }

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, cast
 import charms.proxylib
 from lightkube import Client
 from lightkube.codecs import AnyResource, from_dict
-from lightkube.models.core_v1 import Event, Pod, Toleration
+from lightkube.models.core_v1 import Event, Pod, Taint, Toleration
 from ops.interface_kube_control import KubeControlRequirer
 from ops.manifests import (
     Addition,
@@ -128,17 +128,15 @@ class UpdateCSIDriver(Patch):
         log.info(f"Applying Control Node Selector as {node_selector_text}")
         obj.spec.template.spec.nodeSelector = node_selector
 
-        current_tolerations = obj.spec.template.spec.tolerations or []
-        missing_tolerations = [
+        obj.spec.template.spec.tolerations = [
             Toleration(
+                effect=taint.effect,
                 key=taint.key,
                 value=taint.value,
-                effect=taint.effect,
+                operator="Equal" if taint.value else "Exists",
             )
             for taint in self.manifests.config.get("control-node-taints", [])
-            if taint.key not in {toleration.key for toleration in current_tolerations}
         ]
-        obj.spec.template.spec.tolerations = current_tolerations + missing_tolerations
         log.info("Setting Control Node tolerations")
 
     def _update_secrets(self, volumes):
@@ -206,7 +204,7 @@ class StorageManifests(Manifests):
             "cloud-conf": (val := self.integrator.cloud_conf_b64) and val.decode(),
             "control-node-selector": controller_labels,
             "control-node-taints": self.kube_control.get_controller_taints()
-            or [Toleration("NoSchedule", "node-role.kubernetes.io/control-plane")],  # by default
+            or [Taint("NoSchedule", "node-role.kubernetes.io/control-plane")],  # by default
             "endpoint-ca-cert": (val := self.integrator.endpoint_tls_ca) and val.decode(),
             **self.charm_config.available_data,
         }

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -114,12 +114,12 @@ class UpdateCSIDriver(Patch):
             return
 
         log.info(f"Setting secret for {obj.kind}/{obj.metadata.name}")
-        self._update_node_selector(obj)
+        self._update_node_scheduling(obj)
         self._update_secrets(obj.spec.template.spec.volumes)
         self._update_pod_spec(obj.spec.template.spec.containers)
 
-    def _update_node_selector(self, obj):
-        """Update the node selector for the controllerplugin deployment."""
+    def _update_node_scheduling(self, obj):
+        """Update the node selector and tolerations for the controllerplugin deployment."""
         if obj.kind != "Deployment" or obj.metadata.name != "csi-cinder-controllerplugin":
             return
 
@@ -128,16 +128,17 @@ class UpdateCSIDriver(Patch):
         log.info(f"Applying Control Node Selector as {node_selector_text}")
         obj.spec.template.spec.nodeSelector = node_selector
 
-        obj.spec.template.spec.tolerations = [
-            Toleration(
-                effect=taint.effect,
-                key=taint.key,
-                value=taint.value,
-                operator="Equal" if taint.value else "Exists",
-            )
-            for taint in self.manifests.config.get("control-node-taints", [])
-        ]
-        log.info("Setting Control Node tolerations")
+        if taints := self.manifests.config.get("control-node-taints", []):
+            obj.spec.template.spec.tolerations = [
+                Toleration(
+                    effect=taint.effect,
+                    key=taint.key,
+                    value=taint.value,
+                    operator="Equal" if taint.value else "Exists",
+                )
+                for taint in taints
+            ]
+            log.info("Setting Control Node tolerations")
 
     def _update_secrets(self, volumes):
         """Update the volumes in the deployment or daemonset."""
@@ -204,7 +205,9 @@ class StorageManifests(Manifests):
             "cloud-conf": (val := self.integrator.cloud_conf_b64) and val.decode(),
             "control-node-selector": controller_labels,
             "control-node-taints": self.kube_control.get_controller_taints()
-            or [Taint(key="node-role.kubernetes.io/control-plane", effect="NoSchedule")],  # by default
+            or [
+                Taint(key="node-role.kubernetes.io/control-plane", effect="NoSchedule")
+            ],  # by default
             "endpoint-ca-cert": (val := self.integrator.endpoint_tls_ca) and val.decode(),
             **self.charm_config.available_data,
         }

--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, cast
 import charms.proxylib
 from lightkube import Client
 from lightkube.codecs import AnyResource, from_dict
-from lightkube.models.core_v1 import Event, Pod
+from lightkube.models.core_v1 import Event, Pod, Toleration
 from ops.interface_kube_control import KubeControlRequirer
 from ops.manifests import (
     Addition,
@@ -128,6 +128,19 @@ class UpdateCSIDriver(Patch):
         log.info(f"Applying Control Node Selector as {node_selector_text}")
         obj.spec.template.spec.nodeSelector = node_selector
 
+        current_tolerations = obj.spec.template.spec.tolerations or []
+        missing_tolerations = [
+            Toleration(
+                key=taint.key,
+                value=taint.value,
+                effect=taint.effect,
+            )
+            for taint in self.manifests.config.get("control-node-taints", [])
+            if taint.key not in {toleration.key for toleration in current_tolerations}
+        ]
+        obj.spec.template.spec.tolerations = current_tolerations + missing_tolerations
+        log.info("Setting Control Node tolerations")
+
     def _update_secrets(self, volumes):
         """Update the volumes in the deployment or daemonset."""
         for volume in volumes:
@@ -192,6 +205,8 @@ class StorageManifests(Manifests):
             "cluster-name": self.kube_control.get_cluster_tag(),
             "cloud-conf": (val := self.integrator.cloud_conf_b64) and val.decode(),
             "control-node-selector": controller_labels,
+            "control-node-taints": self.kube_control.get_controller_taints()
+            or [Toleration("NoSchedule", "node-role.kubernetes.io/control-plane")],  # by default
             "endpoint-ca-cert": (val := self.integrator.endpoint_tls_ca) and val.decode(),
             **self.charm_config.available_data,
         }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -163,6 +163,7 @@ def test_waits_for_kube_control(mock_create_kubeconfig, harness, caplog):
     assert storage_messages == {
         'Applying Control Node Selector as node-role.kubernetes.io/control-plane: ""',
         "Encode secret data for storage.",
+        "Setting Control Node tolerations",
         "Creating storage class csi-cinder-default",
         "Setting secret for DaemonSet/csi-cinder-nodeplugin",
         "Setting secret for Deployment/csi-cinder-controllerplugin",

--- a/tests/unit/test_storage_manifest.py
+++ b/tests/unit/test_storage_manifest.py
@@ -7,7 +7,7 @@ import os
 import unittest.mock as mock
 
 import pytest
-from lightkube.models.core_v1 import Container, EnvVar, Volume
+from lightkube.models.core_v1 import Container, EnvVar, Taint, Toleration, Volume
 from lightkube.resources.apps_v1 import DaemonSet, Deployment
 
 import storage_manifests
@@ -131,3 +131,101 @@ def test_patch_csi_driver(resource, name, storage, respect_proxy, no_proxy):
         assert "http_proxy" not in keys
         assert "https_proxy" not in keys
         assert "no_proxy" not in keys
+
+
+@pytest.mark.parametrize(
+    "taints,expected",
+    [
+        pytest.param(
+            [],
+            [Taint(key="node-role.kubernetes.io/control-plane", effect="NoSchedule")],
+            id="default-fallback-when-empty",
+        ),
+        pytest.param(
+            [Taint(key="custom-taint", value="custom-value", effect="NoSchedule")],
+            [Taint(key="custom-taint", value="custom-value", effect="NoSchedule")],
+            id="uses-kube-control-taints",
+        ),
+    ],
+)
+def test_config_control_node_taints(taints, expected, kube_control, storage):
+    """Test that control-node-taints uses kube_control or falls back to a default."""
+    kube_control.get_controller_taints.return_value = taints
+    assert storage.config["control-node-taints"] == expected
+
+
+@pytest.mark.parametrize(
+    "taints,expected_tolerations",
+    [
+        pytest.param(
+            [Taint(key="node-role.kubernetes.io/control-plane", effect="NoSchedule")],
+            [
+                Toleration(
+                    key="node-role.kubernetes.io/control-plane",
+                    effect="NoSchedule",
+                    operator="Exists",
+                )
+            ],
+            id="taint-without-value-uses-exists-operator",
+        ),
+        pytest.param(
+            [Taint(key="my-key", value="my-value", effect="NoSchedule")],
+            [Toleration(key="my-key", value="my-value", effect="NoSchedule", operator="Equal")],
+            id="taint-with-value-uses-equal-operator",
+        ),
+        pytest.param(
+            [
+                Taint(key="key1", effect="NoSchedule"),
+                Taint(key="key2", value="val2", effect="NoExecute"),
+            ],
+            [
+                Toleration(key="key1", effect="NoSchedule", operator="Exists"),
+                Toleration(key="key2", value="val2", effect="NoExecute", operator="Equal"),
+            ],
+            id="multiple-taints-to-tolerations",
+        ),
+    ],
+)
+def test_tolerations_set_on_controller_deployment(
+    taints, expected_tolerations, kube_control, storage
+):
+    """Test that tolerations are applied to the csi-cinder-controllerplugin Deployment."""
+    kube_control.get_controller_taints.return_value = taints
+
+    update_rsc = storage.manipulations[-1]
+    assert isinstance(update_rsc, storage_manifests.UpdateCSIDriver)
+
+    rsc = mock.MagicMock(spec=Deployment)
+    rsc.kind = "Deployment"
+    rsc.metadata.name = "csi-cinder-controllerplugin"
+    rsc.spec.template.spec.volumes = []
+    container = mock.MagicMock(spec=Container)
+    container.name = "cinder-csi-plugin"
+    container.env = []
+    rsc.spec.template.spec.containers = [container]
+
+    update_rsc(rsc)
+    assert rsc.spec.template.spec.tolerations == expected_tolerations
+
+
+def test_daemonset_tolerations_not_modified(kube_control, storage):
+    """Test that tolerations are not set on the csi-cinder-nodeplugin DaemonSet."""
+    kube_control.get_controller_taints.return_value = [
+        Taint(key="node-role.kubernetes.io/control-plane", effect="NoSchedule")
+    ]
+
+    update_rsc = storage.manipulations[-1]
+    assert isinstance(update_rsc, storage_manifests.UpdateCSIDriver)
+
+    rsc = mock.MagicMock(spec=DaemonSet)
+    rsc.kind = "DaemonSet"
+    rsc.metadata.name = "csi-cinder-nodeplugin"
+    rsc.spec.template.spec.volumes = []
+    container = mock.MagicMock(spec=Container)
+    container.name = "cinder-csi-plugin"
+    container.env = []
+    rsc.spec.template.spec.containers = [container]
+
+    original_tolerations = rsc.spec.template.spec.tolerations
+    update_rsc(rsc)
+    assert rsc.spec.template.spec.tolerations is original_tolerations


### PR DESCRIPTION
Fixes: 
* [LP#2111904](https://bugs.launchpad.net/charm-cinder-csi/+bug/2111904)
* Introduced in #15 


This pull request enhances how control node tolerations are managed and applied in the storage manifests, ensuring that workloads are properly scheduled on control-plane nodes when required. The main changes involve updating the manifest configuration to support  tolerations, as well as improving logging and test coverage to reflect these updates.

**Kubernetes control-plane scheduling improvements:**

* Added support for specifying and applying tolerations for control-plane node taints in the manifest configuration, ensuring workloads can be scheduled on tainted control-plane nodes as needed. (`src/storage_manifests.py`) [[1]](diffhunk://#diff-d8cdb19e9044b2beeceebc86de8f2c8f63f2d5c6fa3b2ee4e71468c27c880330R131-R143) [[2]](diffhunk://#diff-d8cdb19e9044b2beeceebc86de8f2c8f63f2d5c6fa3b2ee4e71468c27c880330R208-R209)
* Defaulted to a `NoSchedule` toleration for the `node-role.kubernetes.io/control-plane` taint if none are provided, improving out-of-the-box compatibility. (`src/storage_manifests.py`)
* Imported the `Toleration` model from `lightkube.models.core_v1` to support the new toleration logic. (`src/storage_manifests.py`)

**Logging and testing:**

* Added a log message when control node tolerations are set, providing better visibility into manifest changes. (`src/storage_manifests.py`)
* Updated unit tests to expect the new log message about setting control node tolerations, ensuring test accuracy. (`tests/unit/test_charm.py`)