### PR TITLE
fix: add usedforsecurity=False to MD5 hash (bandit B324)

### DIFF
--- a/src/storage_manifests.py
+++ b/src/storage_manifests.py
@@ -221,7 +221,7 @@ class StorageManifests(Manifests):
 
     def hash(self) -> int:
         """Calculate a hash of the current configuration."""
-        return int(md5(pickle.dumps(self.config)).hexdigest(), 16)
+        return int(md5(pickle.dumps(self.config), usedforsecurity=False).hexdigest(), 16)
 
     def evaluate(self) -> Optional[str]:
         """Determine if manifest_config can be applied to manifests."""


### PR DESCRIPTION
## Summary

Fix HIGH severity bandit finding B324 (CWE-327) in `src/storage_manifests.py`.

## Details

The `md5()` call on line 224 is used for configuration change detection (hashing a pickled config dict), not for any security purpose. Adding `usedforsecurity=False` documents this intent and satisfies bandit's check.

### Before
```python
return int(md5(pickle.dumps(self.config)).hexdigest(), 16)
```

### After
```python
return int(md5(pickle.dumps(self.config), usedforsecurity=False).hexdigest(), 16)
```

## Context
Found by bandit SAST scan added in #18.